### PR TITLE
Use from-file instead of from-literal

### DIFF
--- a/content/en/docs/install/_index.md
+++ b/content/en/docs/install/_index.md
@@ -117,7 +117,7 @@ Depending on your security choices, you must create a secret containing both TLS
 
 ```sh
 export NAMESPACE="my-namespace"
-kubectl create secret generic streams-database-secret --from-literal=CA_PEM="$(cat ca.pem)" --from-literal=SERVER_CERT_PEM="$(cat server-cert.pem)" --from-literal=SERVER_KEY_PEM="$(cat server-key.pem)" --from-literal=KEYFILE="$(cat keyfile)" -n ${NAMESPACE}
+kubectl create secret generic streams-database-secret --from-file=CA_PEM=ca.pem --from-file=SERVER_CERT_PEM=server-cert.pem --from-file=SERVER_KEY_PEM=server-key.pem --from-file=KEYFILE=keyfile -n ${NAMESPACE}
 ```
 
 or only for TLS


### PR DESCRIPTION
Thank you for your contribution to the Axway Streams documentation.

## Describe the changes

The command used to create database secret wasn't working properly on some configuration. I replace it with --from-file as we read data from file not literal.

## Checklist for contributors

Before submitting this PR, please make sure:

* [x] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [x] You have signed the [Axway CLA](https://cla.axway.com/)
* [x] You have verified the technical accuracy of your change
* [x] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [x] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._

## Checklist for approvers

_This section is to be filled out by project maintainers only._

Before approving this PR, please make sure it:

* [ ] Does not have conflicts with the base branch
* [ ] Is believed to be accurate (technical accuracy to be checked with an SME for PRs originating from outside R&D)
* [ ] Follows [Axway style](https://techweb.axway.com/confluence/display/RIE/Style+guide)
* [ ] Follows [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)
* [ ] Follows [best practices](https://axway-open-docs.netlify.com/docs/contribution_guidelines/bestpracticedevdoc/)
* [ ] Does not contain typos, grammatical errors, etc.
* [ ] Does not expose any sensitive information
* [ ] Passes the Markdown linter rules (automated via CI check)
* [ ] Does not contain broken links
