### PR TITLE
STREAMS-1169 doc(install): change config parameter after zookeper ref…

### DIFF
--- a/content/en/docs/install/_index.md
+++ b/content/en/docs/install/_index.md
@@ -341,7 +341,7 @@ Refer to the [Helm parameters](#helm-parameters) for further details.
 | publisherSfdc.replicaCount            | Publisher SFDC replica count        | no        | 2             |
 | mariadb.metrics.enabled               | Activate metrics endpoint for MariaDB | no      | false         |
 | kafka.metrics.jmx.enabled             | Activate metrics endpoint for Kafka | no        | false         |
-| kafka.zookeeper.metrics.enabled       | Activate metrics endpoint for Zookeeper | no    | false         |
+| zookeeper.metrics.enabled             | Activate metrics endpoint for Zookeeper | no    | false         |
 | ingress-nginx.controller.metrics.enabled | Activate metrics endpoint for Ingress controller | no | false |
 | actuator.prometheus.enabled           | Activate metrics endpoints for Streams services | no | false    |
 

--- a/content/en/docs/install/_index.md
+++ b/content/en/docs/install/_index.md
@@ -340,7 +340,8 @@ Refer to the [Helm parameters](#helm-parameters) for further details.
 | publisherSfdc.enabled                 | Enable/Disable Publisher SFDC       | no        | false         |
 | publisherSfdc.replicaCount            | Publisher SFDC replica count        | no        | 2             |
 | mariadb.metrics.enabled               | Activate metrics endpoint for MariaDB | no      | false         |
-| kafka.metrics.jmx.enabled             | Activate metrics endpoint for Kafka | no        | false         |
+| kafka.metrics.kafka.enabled           | Activate metrics endpoint for Kafka | no        | false         |
+| kafka.metrics.jmx.enabled             | Activate metrics endpoint for Kafka additional metrics | no        | false         |
 | zookeeper.metrics.enabled             | Activate metrics endpoint for Zookeeper | no    | false         |
 | ingress-nginx.controller.metrics.enabled | Activate metrics endpoint for Ingress controller | no | false |
 | actuator.prometheus.enabled           | Activate metrics endpoints for Streams services | no | false    |


### PR DESCRIPTION
Thank you for your contribution to the Axway Streams documentation.

## Describe the changes

Change metrics parameter in helm attributes after zookeper externalization

## Checklist for contributors

Before submitting this PR, please make sure:

* [x] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [x] You have signed the [Axway CLA](https://cla.axway.com/)
* [x] You have verified the technical accuracy of your change
* [x] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [x] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._

## Checklist for approvers

_This section is to be filled out by project maintainers only._

Before approving this PR, please make sure it:

* [ ] Does not have conflicts with the base branch
* [ ] Is believed to be accurate (technical accuracy to be checked with an SME for PRs originating from outside R&D)
* [ ] Follows [Axway style](https://techweb.axway.com/confluence/display/RIE/Style+guide)
* [ ] Follows [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)
* [ ] Follows [best practices](https://axway-open-docs.netlify.com/docs/contribution_guidelines/bestpracticedevdoc/)
* [ ] Does not contain typos, grammatical errors, etc.
* [ ] Does not expose any sensitive information
* [ ] Passes the Markdown linter rules (automated via CI check)
* [ ] Does not contain broken links
