### PR TITLE
RMF-69 Update /.github/CODEOWNERS to remove a user

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 #*       @global-owner1 @global-owner2
 
 # Global reviewers for this project
-* @andreamussap @allandenis38 @lbadenhop
+* @allandenis38 @lbadenhop
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only
@@ -17,11 +17,11 @@
 #*.js @js-owner
 
 # Config files
-*.html @andreamussap @allandenis38 @lbadenhop
-*.js   @andreamussap @allandenis38 @lbadenhop
-*.toml @andreamussap @allandenis38 @lbadenhop
-*.yml  @andreamussap @allandenis38 @lbadenhop
-*.json @andreamussap @allandenis38 @lbadenhop
+*.html @allandenis38 @lbadenhop
+*.js   @allandenis38 @lbadenhop
+*.toml @allandenis38 @lbadenhop
+*.yml  @allandenis38 @lbadenhop
+*.json @allandenis38 @lbadenhop
 
 # You can also use email addresses if you prefer. They'll be
 # used to look up users just like we do for commit author
@@ -35,10 +35,10 @@
 
 # Theme and CMS config files
 /layouts/ @andreamussap @allandenis38
-/static/admin/ @andreamussap @allandenis38 @lbadenhop
+/static/admin/ @allandenis38 @lbadenhop
 
 # Documentation files
-/content/en/docs/ @andreamussap @allandenis38 @lbadenhop
+/content/en/docs/ @allandenis38 @lbadenhop
 
 # The `docs/*` pattern will match files like
 # `docs/getting-started.md` but not further nested files like


### PR DESCRIPTION
@allandenis38 as we've agreed I removed my name from the codeowners, so I stop receiving all notifications for new PRs. I noticed thought that @lbadenhop wasn't automatically added to the Reviewers. So I remembered that she had to be added as Admin in the streams-open-docs project. I've added Lisa, as you can see at https://github.com/Axway/streams-open-docs/settings/access, and after that she was automatically added. I believe this is going to work for all PRs from now on. Let me know if/when you guys need any help with the Streams project. 