### PR TITLE
STREAMS-1528 - Add documentation about new webhook testing endpoint 

### DIFF
--- a/content/en/docs/subscribers/subscriber-kafka.md
+++ b/content/en/docs/subscribers/subscriber-kafka.md
@@ -84,11 +84,11 @@ You can test a kafka subscription by making an HTTP Post request on the followin
 
 `POST /subscribers/webhook/subscriptions/{subscriptionId}/test`
 
-The body could contain any JSON object and will be sent as is to the subscription identified.
+The request body can contain any JSON object and will be sent as is to the identified subscription.
 
 ### Test status codes
 
-Below the list of HTTP status codes that can be returned when trying to test a kafka subscription:
+Below the list of HTTP status codes that can be returned while testing a Kafka subscription:
 
 | Code | Comment |
 |------|---------|
@@ -98,7 +98,7 @@ Below the list of HTTP status codes that can be returned when trying to test a k
 
 ## Getting kafka subscriptions for a topic
 
-In order to get existing subscriptions, simply do the following GET request on your topic:
+In order to get existing subscriptions, just do the following `GET` request on your topic:
 
 `GET /subscribers/kafka/topics/{topicId}/subscriptions`
 

--- a/content/en/docs/subscribers/subscriber-kafka.md
+++ b/content/en/docs/subscribers/subscriber-kafka.md
@@ -88,7 +88,7 @@ The request body can contain any JSON object and will be sent as is to the ident
 
 ### Test status codes
 
-Below the list of HTTP status codes that can be returned while testing a Kafka subscription:
+The following HTTP status codes can be returned while testing a Kafka subscription:
 
 | Code | Comment |
 |------|---------|

--- a/content/en/docs/subscribers/subscriber-kafka.md
+++ b/content/en/docs/subscribers/subscriber-kafka.md
@@ -98,7 +98,7 @@ The following HTTP status codes can be returned while testing a Kafka subscripti
 
 ## Getting kafka subscriptions for a topic
 
-In order to get existing subscriptions, just do the following `GET` request on your topic:
+Use the following `GET` request on your topic to get existing subscriptions:
 
 `GET /subscribers/kafka/topics/{topicId}/subscriptions`
 

--- a/content/en/docs/subscribers/subscriber-kafka.md
+++ b/content/en/docs/subscribers/subscriber-kafka.md
@@ -80,7 +80,7 @@ List of HTTP status codes that can be returned when trying to get a kafka subscr
 
 ## Testing a Kafka subscription
 
-You can test a kafka subscription by making an HTTP Post request on the following endpoint:
+You can test a Kafka subscription by making an HTTP POST request on the following endpoint:
 
 `POST /subscribers/kafka/subscriptions/{subscriptionId}/test`
 

--- a/content/en/docs/subscribers/subscriber-kafka.md
+++ b/content/en/docs/subscribers/subscriber-kafka.md
@@ -78,7 +78,7 @@ List of HTTP status codes that can be returned when trying to get a kafka subscr
 | 200 Ok | Indicates that the subscription requested is valid and has been retrieved. |
 | 404 Not found | Indicates that the requested URL or subscription requested does not exist. |
 
-## Testing a kafka subscription
+## Testing a Kafka subscription
 
 You can test a kafka subscription by making an HTTP Post request on the following endpoint:
 

--- a/content/en/docs/subscribers/subscriber-kafka.md
+++ b/content/en/docs/subscribers/subscriber-kafka.md
@@ -78,6 +78,24 @@ List of HTTP status codes that can be returned when trying to get a kafka subscr
 | 200 Ok | Indicates that the subscription requested is valid and has been retrieved. |
 | 404 Not found | Indicates that the requested URL or subscription requested does not exist. |
 
+## Testing a kafka subscription
+
+You can test a kafka subscription by making an HTTP Post request on the following endpoint:
+
+`POST /subscribers/webhook/subscriptions/{subscriptionId}/test`
+
+The body could contain any JSON object and will be sent as is to the subscription identified.
+
+### Test status codes
+
+Below the list of HTTP status codes that can be returned when trying to test a kafka subscription:
+
+| Code | Comment |
+|------|---------|
+| 202 Accepted | Indicates that the payload has been successufuly sent to the subscription. |
+| 400 Bad Request | Indicates that the provided data are invalid. |
+| 404 Not found | Indicates that the requested URL does not exist. |
+
 ## Getting kafka subscriptions for a topic
 
 In order to get existing subscriptions, simply do the following GET request on your topic:

--- a/content/en/docs/subscribers/subscriber-kafka.md
+++ b/content/en/docs/subscribers/subscriber-kafka.md
@@ -82,7 +82,7 @@ List of HTTP status codes that can be returned when trying to get a kafka subscr
 
 You can test a kafka subscription by making an HTTP Post request on the following endpoint:
 
-`POST /subscribers/webhook/subscriptions/{subscriptionId}/test`
+`POST /subscribers/kafka/subscriptions/{subscriptionId}/test`
 
 The request body can contain any JSON object and will be sent as is to the identified subscription.
 

--- a/content/en/docs/subscribers/subscriber-webhook.md
+++ b/content/en/docs/subscribers/subscriber-webhook.md
@@ -82,11 +82,11 @@ You can test a webhook subscription by making an HTTP Post request on the follow
 
 `POST /subscribers/webhook/subscriptions/{subscriptionId}/test`
 
-The body could contain any JSON object and will be sent as is to the subscription identified.
+The request body can contain any JSON object and will be sent as is to the identified subscription.
 
 ### Test status codes
 
-Below the list of HTTP status codes that can be returned when trying to test a webhook subscription:
+Below the list of HTTP status codes that can be returned while testing a webhook subscription:
 
 | Code | Comment |
 |------|---------|

--- a/content/en/docs/subscribers/subscriber-webhook.md
+++ b/content/en/docs/subscribers/subscriber-webhook.md
@@ -76,6 +76,24 @@ Below the list of HTTP status codes that can be returned when trying to get a ka
 | 200 Ok | Indicates that the subscription requested is valid and has been retrieved. |
 | 404 Not found | Indicates that the requested URL or subscription requested does not exist. |
 
+## Testing a webhook subscription
+
+You can test a webhook subscription by making an HTTP Post request on the following endpoint:
+
+`POST /subscribers/webhook/subscriptions/{subscriptionId}/test`
+
+The body could contain any JSON object and will be sent as is to the subscription identified.
+
+### Test status codes
+
+Below the list of HTTP status codes that can be returned when trying to test a webhook subscription:
+
+| Code | Comment |
+|------|---------|
+| 202 Accepted | Indicates that the payload has been successufuly sent to the subscription. |
+| 400 Bad Request | Indicates that the provided data are invalid. |
+| 404 Not found | Indicates that the requested URL does not exist. |
+
 ## Getting webhook subscriptions for a topic
 
 In order to get existing subscriptions, simply do the following GET request on your topic:

--- a/content/en/docs/subscribers/subscriber-webhook.md
+++ b/content/en/docs/subscribers/subscriber-webhook.md
@@ -86,7 +86,7 @@ The request body can contain any JSON object and will be sent as is to the ident
 
 ### Test status codes
 
-Below the list of HTTP status codes that can be returned while testing a webhook subscription:
+The following HTTP status codes can be returned while testing a webhook subscription:
 
 | Code | Comment |
 |------|---------|

--- a/content/en/docs/subscribers/subscriber-webhook.md
+++ b/content/en/docs/subscribers/subscriber-webhook.md
@@ -96,7 +96,7 @@ The following HTTP status codes can be returned while testing a webhook subscrip
 
 ## Getting webhook subscriptions for a topic
 
-In order to get existing subscriptions, simply do the following GET request on your topic:
+To get existing subscriptions, do the following GET request on your topic:
 
 `GET /subscribers/webhook/topics/{topicId}/subscriptions`
 


### PR DESCRIPTION
Thank you for your contribution to the Axway Streams documentation.

## Describe the changes

add documentation about new test endpoint for webhook and kafka subscribers.

## Checklist for contributors

Before submitting this PR, please make sure:

* [x] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [x] You have signed the [Axway CLA](https://cla.axway.com/)
* [x] You have verified the technical accuracy of your change
* [x] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [x] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._

## Checklist for approvers

_This section is to be filled out by project maintainers only._

Before approving this PR, please make sure it:

* [x] Does not have conflicts with the base branch
* [x] Is believed to be accurate (technical accuracy to be checked with an SME for PRs originating from outside R&D)
* [x] Follows [Axway style](https://techweb.axway.com/confluence/display/RIE/Style+guide)
* [x] Follows [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)
* [x] Follows [best practices](https://axway-open-docs.netlify.com/docs/contribution_guidelines/bestpracticedevdoc/)
* [x] Does not contain typos, grammatical errors, etc.
* [x] Does not expose any sensitive information
* [x] Passes the Markdown linter rules (automated via CI check)
* [x] Does not contain broken links
