### PR TITLE
STREAMS-1895 feat : explain newly simplified postman environment

### DIFF
--- a/content/en/docs/install/_index.md
+++ b/content/en/docs/install/_index.md
@@ -512,10 +512,10 @@ my-release-subscriber-webhook-84469bd68f-lqxgk                 1/1     Running  
 [...]
 ```
 
-In order to check that Streams is running:
+To check that Streams is running:
 
 1. Import the provided Postman collections and environments. Select the environment designed
-for Kubernetes (instead of localhost). It has a variable named "loadBalancerBaseUrl" with the value "<SET_YOUR_HOSTNAME>". Change this to your hostname (e.g. "https://k8s.yourdomain.tld").
+for Kubernetes (instead of localhost). It has a variable named `loadBalancerBaseUrl` with the value `<SET_YOUR_HOSTNAME>`. Change this to your hostname (for example, `https://k8s.yourdomain.tld`).
 2. Create a topic with default settings.
 3. Try to subscribe with SSE to your topic:
 

--- a/content/en/docs/install/_index.md
+++ b/content/en/docs/install/_index.md
@@ -514,9 +514,10 @@ my-release-subscriber-webhook-84469bd68f-lqxgk                 1/1     Running  
 
 In order to check that Streams is running:
 
-1. Create a topic with default settings using the provided Postman collection and Postman environment.
-As the provided environment is configured with `${loadbalancer.baseUrl}` for all base URLs, you must reconfigure it with your own DNS. For example, `baseUrl` will be changed from `${loadbalancer.baseUrl}` to `https://k8s.yourdomain.tld` and so on for other variables.
-2. Try to subscribe with SSE to your topic:
+1. Import the provided Postman collections and environments. Select the environment designed
+for Kubernetes (instead of localhost). It has a variable named "loadBalancerBaseUrl" with the value "<SET_YOUR_HOSTNAME>". Change this to your hostname (e.g. "https://k8s.yourdomain.tld").
+2. Create a topic with default settings.
+3. Try to subscribe with SSE to your topic:
 
 ```sh
 curl "https://k8s.yourdomain.tld/streams/subscribers/sse/api/v1/topics/{TOPIC_ID}"


### PR DESCRIPTION


## Describe the changes

We have simplified the postman K8S env to only need to change a single variable. This PR addresses that as well as further explain the postman env that we are currently supplying to clients

## Checklist for contributors

Before submitting this PR, please make sure:

* [x] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [x] You have signed the [Axway CLA](https://cla.axway.com/)
* [x] You have verified the technical accuracy of your change
* [x] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [x] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._

## Checklist for approvers

_This section is to be filled out by project maintainers only._

Before approving this PR, please make sure it:

* [x] Does not have conflicts with the base branch
* [x] Is believed to be accurate (technical accuracy to be checked with an SME for PRs originating from outside R&D)
* [x] Follows [Axway style](https://techweb.axway.com/confluence/display/RIE/Style+guide)
* [x] Follows [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)
* [x] Follows [best practices](https://axway-open-docs.netlify.com/docs/contribution_guidelines/bestpracticedevdoc/)
* [x] Does not contain typos, grammatical errors, etc.
* [x] Does not expose any sensitive information
* [x] Passes the Markdown linter rules (automated via CI check)
* [x] Does not contain broken links
