### PR TITLE
RMF-185 Revert "Revert "RMF-185 Update sha512 string on postcss version 8.2.10 to fix error when deploying site""

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2070,7 +2070,7 @@
     "postcss": {
       "version": "8.2.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.10.tgz",
-      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+      "integrity": "sha512-b/h7CPV7QEdrqIxtAf2j31U5ef05uBDuvoXv6L51Q4rcS1jdlXAVKJv+atCFdUXYl9dyTHGyoMzIepwowRJjFw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",


### PR DESCRIPTION
Reverts Axway/streams-open-docs#91

This is to put the correct sha512 back - 
"integrity": "sha512-b/h7CPV7QEdrqIxtAf2j31U5ef05uBDuvoXv6L51Q4rcS1jdlXAVKJv+atCFdUXYl9dyTHGyoMzIepwowRJjFw==",