### PR TITLE
STREAMS-2098 Add nodeSelector parameter for Nginx default backend

### DIFF
--- a/content/en/docs/architecture/_index.md
+++ b/content/en/docs/architecture/_index.md
@@ -304,6 +304,10 @@ You must define it for each of the 3rd party pods (NGINX, Kafka, Zookeeper and M
 ```
 nginx-ingress-controller:
   nodeSelector:
+    application: streams
+  [...]
+  defaultBackend:
+    nodeSelector:
       application: streams
 [...]
 embeddedKafka:
@@ -319,7 +323,7 @@ embeddedMariadb:
       application: streams
   slave:
     nodeSelector:
-    application: streams
+      application: streams
 [...]
 ```
 


### PR DESCRIPTION
Thank you for your contribution to the Axway Streams documentation.

## Describe the changes

Fix indent and add the nodeSelector parameter for Nginx default backend
Visible here: https://deploy-preview-106--streams-open-docs.netlify.app/docs/architecture/

## Checklist for contributors

Before submitting this PR, please make sure:

* [x] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [x] You have signed the [Axway CLA](https://cla.axway.com/)
* [x] You have verified the technical accuracy of your change
* [x] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [x] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)
