### PR TITLE
STREAMS-2319 Embedded Kafka: add missing helm parameters to set if Security is disabled

### DIFF
--- a/content/en/docs/install/_index.md
+++ b/content/en/docs/install/_index.md
@@ -370,6 +370,8 @@ You can choose one of the following options:
         * `embeddedKafka.auth.saslInterBrokerMechanism` to `plain`
         * `embeddedKafka.auth.jaas.existingSecret` to `null`
         * `embeddedKafka.extraEnvVars` to `null`
+        * `embeddedKafka.extraVolumes` to `null`
+        * `embeddedKafka.extraVolumeMounts` to `null`
 
 {{< alert title="Note" >}}
 Disabling security is not recommended for production environments.

--- a/content/en/docs/security/_index.md
+++ b/content/en/docs/security/_index.md
@@ -3,5 +3,5 @@ title: Streams Security Guidance
 linkTitle: Security Guidance
 weight: 8
 date: 2020-09-18
-description: This section describes how the the product was developed in a secure way, and provides a link to the Streams Security guide.
+description: This section describes how the product was developed in a secure way, and provides a link to the Streams Security guide.
 ---

--- a/content/en/docs/security/security-guide.md
+++ b/content/en/docs/security/security-guide.md
@@ -7,4 +7,4 @@ description: Security features of Streams
 ---
 
 The Streams Security guide is available at the following link: [Streams Security guide](https://docs.axway.com/bundle/Streams_20_SecurityGuide_allOS_en_HTML5/).
-Please note that the Streams Security guide is in restricted availibility.
+Please note that the Streams Security guide is in restricted availability.


### PR DESCRIPTION
Thank you for your contribution to the Axway Streams documentation.

Update pages:

- https://deploy-preview-127--streams-open-docs.netlify.app/docs/install/#embedded-kafka-security-settings
- https://deploy-preview-127--streams-open-docs.netlify.app/docs/security/

## Describe the changes

- Embedded Kafka: Add missing helm parameters to set if Security is disabled.
- Fix 2 typo in the Security section not linked to the story

## Checklist for contributors

Before submitting this PR, please make sure:

* [x] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [x] You have signed the [Axway CLA](https://cla.axway.com/)
* [x] You have verified the technical accuracy of your change
* [x] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [x] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)
