### PR TITLE
STREAMS-2216 - add OAuth2 Authorization support for subscriber webhook

### DIFF
--- a/content/en/docs/publishers/publisher-http-poller.md
+++ b/content/en/docs/publishers/publisher-http-poller.md
@@ -30,7 +30,7 @@ The HTTP poller publisher requires the following specific configuration.
 | retryBackOffMaxDuration       | no        | PT10S          | Maximum period of time between two attempts (ISO-8601 format). Min = PT0S (0s); Max = PT60S (60s). |
 | retryBackOffFactor            | no        | 0.5            | The factor used to determine the next retry duration. |
 | computedQueryParameters       | no        | none           | Map of [ComputedQueryParameters](/docs/publishers/publisher-http-poller/#computed-query-parameters) that will be injected as query parameters. The key, query parameter name, must use URL-safe characters. For more information, see [Unreserved Characters](https://datatracker.ietf.org/doc/html/rfc2396#section-2.3). |
-| authorization                 | no        | N/A            | OAuth2 Authorization configuration. For more information, see section [OAuth2 Authorization](#authorization_with_oauth_2_0) |
+| authorization                 | no        | N/A            | OAuth2 Authorization configuration. For more information, see section [OAuth2 Authorization](#authorization-with-oauth-2-0) |
 | pagination                    | no        | N/A            | Pagination mechanism configuration. For more information, see section [Pagination](#pagination) |
 
 The following is an example of an HTTP poller publisher:

--- a/content/en/docs/publishers/publisher-http-poller.md
+++ b/content/en/docs/publishers/publisher-http-poller.md
@@ -30,6 +30,7 @@ The HTTP poller publisher requires the following specific configuration.
 | retryBackOffMaxDuration       | no        | PT10S          | Maximum period of time between two attempts (ISO-8601 format). Min = PT0S (0s); Max = PT60S (60s). |
 | retryBackOffFactor            | no        | 0.5            | The factor used to determine the next retry duration. |
 | computedQueryParameters       | no        | none           | Map of [ComputedQueryParameters](/docs/publishers/publisher-http-poller/#computed-query-parameters) that will be injected as query parameters. The key, query parameter name, must use URL-safe characters. For more information, see [Unreserved Characters](https://datatracker.ietf.org/doc/html/rfc2396#section-2.3). |
+| authorization                 | no        | N/A            | OAuth2 Authorization configuration. For more information, see section [OAuth2 Authorization](#authorization_with_oauth_2_0) |
 | pagination                    | no        | N/A            | Pagination mechanism configuration. For more information, see section [Pagination](#pagination) |
 
 The following is an example of an HTTP poller publisher:

--- a/content/en/docs/subscribers/subscriber-webhook.md
+++ b/content/en/docs/subscribers/subscriber-webhook.md
@@ -22,9 +22,17 @@ The body must contain a JSON webhook subscription configuration as the following
 {
     "webhookUrl": "https://valid.url/of/webhook",
     "webhookHeaders": {
-      "Authorization"   : "Bearer AbCdEf123456"
+      "additionalHeader": "value"
     },
-    "subscriptionMode": "snapshot-only"
+    "subscriptionMode": "snapshot-only",
+    "authorization": {
+        "type": "oauth2",
+        "clientId": "myclientId",
+        "clientSecret": "myclientSecret",
+        "provider": "http://authorization.com/oauth/token",
+        "scope": "READ,WRITE",
+        "mode": "body"
+    }
 }
 ```
 
@@ -32,9 +40,48 @@ The body must contain a JSON webhook subscription configuration as the following
 |---------------------|-----------|---------------|-------------|
 | webhookUrl | yes | n/a | URL which will be called by Streams in order to inform the subscriber that a new event/message has been published in the topic identified by {topicId}. |
 | webhookHeaders | no | n/a | Map of key/value which will send by Streams to the subscriber |
-| subscriptionMode | no | Default subscription mode defined in the topic's configuration | Refer to [subscription modes](/docs/subscribers/#subscription-modes) section |
+| subscriptionMode | no | Default subscription mode defined in the topic's configuration | For more information, see section [subscription modes](/docs/subscribers/#subscription-modes) |
+| authorization | no | n/a | OAuth2 Authorization configuration. For more information, see section [OAuth2 Authorization](/#authorization_with_oauth_2_0) |
 
 Once the webhook subscription is successfully created, Streams will start notifying the subscriber at the specified `webhookUrl`.
+
+## Authorization with OAuth 2.0
+
+The Webhook subscriber can post data to an API that is secured with [OAuth2](https://datatracker.ietf.org/doc/html/rfc6749) protocol. Because the Webhook subscriber authenticates to the authorization server without any end-user interaction, the only OAuth2 authorization grant type supported is the [client credentials](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4).
+
+The OAuth2 authorization workflow is implemented with the following limitations:
+
+* The OAuth2 authorization workflow is initiated on the authorization server URL each time a data is posted. Refresh token mechanism is not implemented.
+* Only access token of type [Bearer](https://datatracker.ietf.org/doc/html/rfc6749#section-7.1) is supported.
+* The authorization request is made via a `POST` method on the authorization server, and the client credentials are sent either via `header` or `body`.
+
+The following table lists the OAuth2 authorization configuration:
+
+| Attribute                     | Mandatory | Default value  | Description            |
+| ----------------------------- | --------- | -------------- | ---------------------- |
+| type                          | yes       | none           | Type of authorization protocol configured on the API. Currently, only `oauth2` is supported. |
+| clientId                      | yes       | none           | The client identifier issued during the registration process.  |
+| clientSecret                  | yes       | none           | The client secret issued during the registration process.  |
+| provider                      | yes       | none           | Target URL of the authorization server. |
+| mode                          | yes       | header         | Whether to send [client authentication](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1) via `body` or a basic authorization `header`. |
+| scope                         | no        | none           | A [scope](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3) request parameter. |
+
+The following is an example of how to implement OAuth authorization:
+
+```json
+{
+  "webhookUrl": "https://valid.url/of/webhook",
+  "subscriptionMode": "snapshot-only",
+  "authorization": {
+    "type": "oauth2",
+    "clientId": "myclientId",
+    "clientSecret": "myclientSecret",
+    "provider": "http://authorization.com/oauth/token",
+    "scope": "READ,WRITE",
+    "mode": "body"
+  }
+}
+```
 
 ### Create status codes
 

--- a/content/en/docs/subscribers/subscriber-webhook.md
+++ b/content/en/docs/subscribers/subscriber-webhook.md
@@ -41,7 +41,7 @@ The body must contain a JSON webhook subscription configuration as the following
 | webhookUrl | yes | n/a | URL which will be called by Streams in order to inform the subscriber that a new event/message has been published in the topic identified by `{topicId}`. |
 | webhookHeaders | no | n/a | Map of key/value which will send by Streams to the subscriber. |
 | subscriptionMode | no | Default subscription mode defined in the topic's configuration | For more information, see section [subscription modes](/docs/subscribers/#subscription-modes). |
-| authorization | no | n/a | OAuth2 Authorization configuration. For more information, see section [OAuth2 Authorization](/#authorization-with-oauth-2-0). |
+| authorization | no | n/a | OAuth2 Authorization configuration. For more information, see section [OAuth2 Authorization](#authorization-with-oauth-2-0). |
 
 After the webhook subscription is successfully created, Streams starts notifying the subscriber at the specified `webhookUrl`.
 

--- a/content/en/docs/subscribers/subscriber-webhook.md
+++ b/content/en/docs/subscribers/subscriber-webhook.md
@@ -38,12 +38,12 @@ The body must contain a JSON webhook subscription configuration as the following
 
 | Configuration Entry | Mandatory | Default value | Description |
 |---------------------|-----------|---------------|-------------|
-| webhookUrl | yes | n/a | URL which will be called by Streams in order to inform the subscriber that a new event/message has been published in the topic identified by {topicId}. |
-| webhookHeaders | no | n/a | Map of key/value which will send by Streams to the subscriber |
-| subscriptionMode | no | Default subscription mode defined in the topic's configuration | For more information, see section [subscription modes](/docs/subscribers/#subscription-modes) |
-| authorization | no | n/a | OAuth2 Authorization configuration. For more information, see section [OAuth2 Authorization](/#authorization_with_oauth_2_0) |
+| webhookUrl | yes | n/a | URL which will be called by Streams in order to inform the subscriber that a new event/message has been published in the topic identified by `{topicId}`. |
+| webhookHeaders | no | n/a | Map of key/value which will send by Streams to the subscriber. |
+| subscriptionMode | no | Default subscription mode defined in the topic's configuration | For more information, see section [subscription modes](/docs/subscribers/#subscription-modes). |
+| authorization | no | n/a | OAuth2 Authorization configuration. For more information, see section [OAuth2 Authorization](/#authorization-with-oauth-2-0). |
 
-Once the webhook subscription is successfully created, Streams will start notifying the subscriber at the specified `webhookUrl`.
+After the webhook subscription is successfully created, Streams starts notifying the subscriber at the specified `webhookUrl`.
 
 ## Authorization with OAuth 2.0
 
@@ -51,7 +51,7 @@ The Webhook subscriber can post data to an API that is secured with [OAuth2](htt
 
 The OAuth2 authorization workflow is implemented with the following limitations:
 
-* The OAuth2 authorization workflow is initiated on the authorization server URL each time a data is posted. Refresh token mechanism is not implemented.
+* The OAuth2 authorization workflow is initiated on the authorization server URL each time data is posted. Refresh token mechanism is not implemented.
 * Only access token of type [Bearer](https://datatracker.ietf.org/doc/html/rfc6749#section-7.1) is supported.
 * The authorization request is made via a `POST` method on the authorization server, and the client credentials are sent either via `header` or `body`.
 


### PR DESCRIPTION
Thank you for your contribution to the Axway Streams documentation.

## Describe the changes

* add Oauth Authorization support for subscriber Webhook
* add the missing authorization section in the HTTP Poller publisher table

https://deploy-preview-128--streams-open-docs.netlify.app/docs/subscribers/subscriber-webhook/
https://deploy-preview-128--streams-open-docs.netlify.app/docs/publishers/publisher-http-poller/#understand-http-poller-publisher-configuration

## Checklist for contributors

Before submitting this PR, please make sure:

* [x] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [x] You have signed the [Axway CLA](https://cla.axway.com/)
* [x] You have verified the technical accuracy of your change
* [x] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [x] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)
