### PR TITLE
RDAPI-26352 and RMF-269 Update Docsy theme

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -94,6 +94,9 @@ github_repo = "https://github.com/Axway/streams-open-docs"
 # Enable Algolia search
 algolia_docsearch = true
 
+# Enable syntax highlighting and copy buttons on code blocks with Prism
+prism_syntax_highlighting = true
+
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.


### PR DESCRIPTION
RDAPI-26352 Update Docsy theme to enable **Copy to clipboard** button. 

https://deploy-preview-139--streams-open-docs.netlify.app/docs/publishers/#selecting-your-type-of-publisher