### PR TITLE
RDAPI-28008 Update Hugo version

### DIFF
--- a/.github/workflows/ciworkflow.yml
+++ b/.github/workflows/ciworkflow.yml
@@ -29,5 +29,5 @@ jobs:
     # Runs markdownlint
     - name: Run markdown linter
       run: |
-        npm i -g markdownlint-cli
+        npm i -g markdownlint-cli@0.31.1
         markdownlint "content/en/**/*.md"      

--- a/config.toml
+++ b/config.toml
@@ -34,7 +34,7 @@ blog = "/:section/:year/:month/:day/:slug/"
 
 ## Markup config
 [markup]
-  defaultMarkdownHandler = "blackFriday"
+  #defaultMarkdownHandler = "blackFriday"
   
   [markup.blackFriday]
   plainIDAnchors = true
@@ -47,7 +47,7 @@ blog = "/:section/:year/:month/:day/:slug/"
   
   [markup.goldmark]
     [markup.goldmark.renderer]
-      #unsafe = true #this overrides the default setting of false
+      unsafe = true #this overrides the default setting of false and allows goldmark to render HTML as well as Markdown
 
 # Image processing configuration.
 [imaging]

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@ command = "bash build.sh -n"
 
 # "production" environment specific build settings
 [build.environment]
-HUGO_VERSION = "0.66.0"
+HUGO_VERSION = "0.101.0"
 
 [context.production.environment]
 HUGO_ENV = "production"


### PR DESCRIPTION
* This is to update Hugo, but it first requires to change the markdown render from BlackFriday to Goldmark.
* Hard code an old version to the CI workflow to avoid markdown issues. See, RMF-306